### PR TITLE
fix(select): add ellipsis to multivalue_label to show multivalueremove

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -3,15 +3,18 @@ import PropTypes from 'prop-types';
 import ReactSelect, { components } from 'react-select';
 import omit from 'lodash/omit';
 import { withTheme } from 'styled-components';
+import get from 'lodash/get';
 
-import {
-  StyledSelect,
-  StyledSelectMultiValue,
-} from '../styles/components/StyledSelect';
+import { StyledSelect } from '../styles/components/StyledSelect';
 import theme from '../styles/theme';
 import withDataId from '../components/DataId/withDataId';
 
 import Icon from './Icon';
+import {
+  fontWeightSemiBold,
+  tagFontSize,
+  tagLineHeight,
+} from '../styles/selectors';
 
 const propTypes = {
   /**
@@ -60,6 +63,33 @@ const defaultProps = {
   dataId: 'select',
 };
 
+const styles = {
+  multiValue: (styles, state) => {
+    return {
+      ...styles,
+      backgroundColor: get(theme.color, state.data.background || 'gray400'),
+      borderRadius: '4px',
+    };
+  },
+  multiValueLabel: (styles, state) => {
+    return {
+      ...styles,
+      color: get(theme.color, state.data.color || 'white'),
+      margin: '4px',
+      fontSize: tagFontSize,
+      fontWeight: fontWeightSemiBold,
+      lineHeight: tagLineHeight,
+    };
+  },
+  multiValueRemove: (styles, state) => {
+    return {
+      ...omit(styles, [':hover', 'backgroundColor']),
+      color: get(theme.color, state.data.color || 'white'),
+      cursor: 'pointer',
+    };
+  },
+};
+
 const DropdownIndicator = props => {
   const iconName = props.selectProps.menuIsOpen ? 'chevron_up' : 'chevron_down';
   return (
@@ -94,16 +124,6 @@ const Option = props => {
     <div data-testid="select-option" title={props.label}>
       <components.Option {...props}>{props.label}</components.Option>
     </div>
-  );
-};
-
-const MultiValue = (selectProps, props) => {
-  const background = selectProps.data.background || 'gray400';
-  const color = selectProps.data.color || 'white';
-  return (
-    <StyledSelectMultiValue background={background} color={color} {...props}>
-      <components.MultiValue {...selectProps} />
-    </StyledSelectMultiValue>
   );
 };
 
@@ -149,10 +169,10 @@ export const Select = forwardRef((props, ref) => {
           Input: selectProps =>
             SelectInput({ ...selectProps, name: props.name }),
           Option: selectProps => Option({ ...selectProps, name: props.name }),
-          MultiValue: selectProps => MultiValue(selectProps, props),
           MultiValueRemove: selectProps => MultiValueRemove(selectProps),
         }}
         {...selectProps}
+        styles={styles}
       />
     </StyledSelect>
   );

--- a/src/styles/components/StyledSelect.js
+++ b/src/styles/components/StyledSelect.js
@@ -1,6 +1,5 @@
 import styled, { css } from 'styled-components';
 import { transparentize } from 'polished';
-import get from 'lodash/get';
 import {
   border,
   borderColor,
@@ -9,7 +8,6 @@ import {
   backgroundColorSelected,
   boxShadow,
   fontColor,
-  gray100,
   fontWeightBold,
   iconColor,
   borderRadius,
@@ -17,11 +15,8 @@ import {
   selectHeight,
   selectPaddingX,
   primaryColor,
-  fontWeightSemiBold,
   boxShadowHover,
-  tagFontSize,
   tagHeight,
-  tagLineHeight,
 } from '../selectors';
 
 export const getSelectSize = props => {
@@ -184,17 +179,6 @@ const StyledSelect = styled.div`
     }
   }
 
-  .select-styled__multi-value {
-    color: ${fontColor};
-    font-size: ${tagFontSize};
-    font-weight: ${fontWeightSemiBold};
-    border: 0px;
-    background: ${gray100};
-    margin: 3px;
-    height: ${tagHeight};
-    line-height: ${tagHeight};
-  }
-
   .select-styled__multi-value__label {
     padding: 0px 0px 0px 6px;
   }
@@ -240,21 +224,4 @@ const StyledSelect = styled.div`
   }
 `;
 
-const StyledSelectMultiValue = styled.div`
-  ${props =>
-    props.background &&
-    `background-color: ${get(props.theme.color, props.background)}`};
-  border-radius: 4px;
-  margin: 4px;
-  .select-styled__multi-value__label {
-    font-size: ${tagFontSize};
-    font-weight: ${fontWeightSemiBold};
-    line-height: ${tagLineHeight};
-    ${props => props.color && `color: ${get(props.theme.color, props.color)}`};
-  }
-  .select-styled__multi-value {
-    background: transparent;
-  }
-`;
-
-export { StyledSelect, StyledSelectMultiValue };
+export { StyledSelect };


### PR DESCRIPTION
What's the issue?
multivalue_remove was hidden on long labels on selectors with multi options
How was resolved?
- Add styles through React Select API instead using a custom component