### PR TITLE
fix(datepicker): add translations from momentJS dependency

### DIFF
--- a/src/components/AntdPicker.js
+++ b/src/components/AntdPicker.js
@@ -1,32 +1,11 @@
 /* eslint-disable camelcase */
 import React, { useEffect, useState } from 'react';
 import { ConfigProvider } from 'antd';
-import ca_ES from 'antd/lib/locale/ca_ES';
-import de_DE from 'antd/lib/locale/de_DE';
-import en_US from 'antd/lib/locale/en_US';
-import en_GB from 'antd/lib/locale/en_GB';
-import es_ES from 'antd/lib/locale/es_ES';
-// import eu_ES from 'antd/lib/locale/eu_ES'; There's no such translation on antd
-import fr_FR from 'antd/lib/locale/fr_FR';
-import it_IT from 'antd/lib/locale/it_IT';
-import pt_PT from 'antd/lib/locale/pt_PT';
-import tr_TR from 'antd/lib/locale/tr_TR';
 import { omit } from 'lodash';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import { withTheme } from 'styled-components';
-import pt_BR from 'antd/lib/locale/pt_BR';
-import el_GR from 'antd/lib/locale/el_GR';
-import nl_NL from 'antd/lib/locale/nl_NL';
-import nl_BE from 'antd/lib/locale/nl_BE';
-import pl_PL from 'antd/lib/locale/pl_PL';
-import bg_BG from 'antd/lib/locale/bg_BG';
-import da_DK from 'antd/lib/locale/da_DK';
-import fi_FI from 'antd/lib/locale/fi_FI';
-// import no_NO from 'antd/lib/locale/no_NO'; There's no such translation on antd
-import sl_SI from 'antd/lib/locale/sl_SI';
-import sv_SE from 'antd/lib/locale/sv_SE';
-import zh_CN from 'antd/lib/locale/zh_CN';
+import * as datePickerUtils from '../utils/datePickerUtils';
+
 import {
   DropdownDatePickerStyles,
   StyledAntdDatePicker,
@@ -46,53 +25,6 @@ import {
 } from '../utils/dates';
 import Icon from './Icon';
 
-// i18n
-const getLocale = language => {
-  switch (language) {
-    case 'bg':
-      return bg_BG;
-    case 'br':
-      return pt_BR;
-    case 'be':
-      return nl_BE;
-    case 'ca':
-      return ca_ES;
-    case 'da':
-      return da_DK;
-    case 'de':
-      return de_DE;
-    case 'el':
-      return el_GR;
-    case 'es':
-      return es_ES;
-    case 'fi':
-      return fi_FI;
-    case 'fr':
-      return fr_FR;
-    case 'it':
-      return it_IT;
-    case 'nl':
-      return nl_NL;
-    case 'pl':
-      return pl_PL;
-    case 'pt':
-      return pt_PT;
-    case 'sl':
-      return sl_SI;
-    case 'sv':
-      return sv_SE;
-    case 'tr':
-      return tr_TR;
-    case 'us':
-      return en_US;
-    case 'zh':
-      return zh_CN;
-    case 'en':
-    default:
-      return en_GB;
-  }
-};
-
 // Ranges
 export const withDatePickerFormat = (start, end) => [start, end];
 const custom = () => withDatePickerFormat(null, null);
@@ -101,7 +33,7 @@ export const datePickerRange = (range, parser = date => date) => {
   if (range === DATE_RANGE.YESTERDAY) return yesterday(parser);
   if (range === DATE_RANGE.LAST_7_DAYS) return last7Days(parser);
   if (range === DATE_RANGE.LAST_28_DAYS) return last28Days(parser);
-  if (range === DATE_RANGE.CURRENET_MONTH) return currentMonth(parser);
+  if (range === DATE_RANGE.CURRENT_MONTH) return currentMonth(parser);
   if (range === DATE_RANGE.LAST_MONTH) return lastMonth(parser);
   if (range === DATE_RANGE.YEAR_TO_DATE) return yearToDate(parser);
   if (range === DATE_RANGE.PREVIOUS_YEAR) return previousYear(parser);
@@ -229,15 +161,13 @@ const AntdPicker = props => {
   ]);
   const { theme, type, language, locale } = props;
 
-  useEffect(() => {
-    moment.locale(language);
-  }, [language]);
-
   return (
     <>
       <ConfigProvider
         locale={
-          (String(language).length === 2 && getLocale(language)) || locale
+          (String(language).length === 2 &&
+            datePickerUtils.getLocale(language)) ||
+          locale
         }
       >
         <DropdownDatePickerStyles theme={theme} />

--- a/src/utils/datePickerUtils.js
+++ b/src/utils/datePickerUtils.js
@@ -1,0 +1,89 @@
+/* eslint-disable camelcase */
+import 'moment/locale/ca';
+import ca_ES from 'antd/lib/locale-provider/ca_ES';
+import 'moment/locale/de';
+import de_DE from 'antd/lib/locale-provider/de_DE';
+import en_US from 'antd/lib/locale-provider/en_US';
+import 'moment/locale/en-gb';
+import en_GB from 'antd/lib/locale-provider/en_GB';
+import 'moment/locale/es';
+import es_ES from 'antd/lib/locale-provider/es_ES';
+// import eu_ES from 'antd/lib/locale/eu_ES'; There's no such translation on antd
+import 'moment/locale/fr';
+import fr_FR from 'antd/lib/locale-provider/fr_FR';
+import 'moment/locale/it';
+import it_IT from 'antd/lib/locale-provider/it_IT';
+import 'moment/locale/pt';
+import pt_PT from 'antd/lib/locale-provider/pt_PT';
+import 'moment/locale/tr';
+import tr_TR from 'antd/lib/locale-provider/tr_TR';
+import 'moment/locale/pt-br';
+import pt_BR from 'antd/lib/locale-provider/pt_BR';
+import 'moment/locale/el';
+import el_GR from 'antd/lib/locale-provider/el_GR';
+import 'moment/locale/nl';
+import nl_NL from 'antd/lib/locale-provider/nl_NL';
+import 'moment/locale/nl-be';
+import nl_BE from 'antd/lib/locale-provider/nl_BE';
+import 'moment/locale/pl';
+import pl_PL from 'antd/lib/locale-provider/pl_PL';
+import 'moment/locale/bg';
+import bg_BG from 'antd/lib/locale-provider/bg_BG';
+import 'moment/locale/da';
+import da_DK from 'antd/lib/locale-provider/da_DK';
+import 'moment/locale/fi';
+import fi_FI from 'antd/lib/locale-provider/fi_FI';
+// import no_NO from 'antd/lib/locale/no_NO'; There's no such translation on antd
+import 'moment/locale/sl';
+import sl_SI from 'antd/lib/locale-provider/sl_SI';
+import 'moment/locale/sv';
+import sv_SE from 'antd/lib/locale-provider/sv_SE';
+import 'moment/locale/zh-cn';
+import zh_CN from 'antd/lib/locale-provider/zh_CN';
+
+// i18n
+export const getLocale = language => {
+  switch (language) {
+    case 'bg':
+      return bg_BG;
+    case 'br':
+      return pt_BR;
+    case 'be':
+      return nl_BE;
+    case 'ca':
+      return ca_ES;
+    case 'da':
+      return da_DK;
+    case 'de':
+      return de_DE;
+    case 'el':
+      return el_GR;
+    case 'es':
+      return es_ES;
+    case 'fi':
+      return fi_FI;
+    case 'fr':
+      return fr_FR;
+    case 'it':
+      return it_IT;
+    case 'nl':
+      return nl_NL;
+    case 'pl':
+      return pl_PL;
+    case 'pt':
+      return pt_PT;
+    case 'sl':
+      return sl_SI;
+    case 'sv':
+      return sv_SE;
+    case 'tr':
+      return tr_TR;
+    case 'us':
+      return en_US;
+    case 'zh':
+      return zh_CN;
+    case 'en':
+    default:
+      return en_GB;
+  }
+};

--- a/src/utils/datePickerUtils.js
+++ b/src/utils/datePickerUtils.js
@@ -4,8 +4,6 @@ import ca_ES from 'antd/lib/locale-provider/ca_ES';
 import 'moment/locale/de';
 import de_DE from 'antd/lib/locale-provider/de_DE';
 import en_US from 'antd/lib/locale-provider/en_US';
-import 'moment/locale/en-gb';
-import en_GB from 'antd/lib/locale-provider/en_GB';
 import 'moment/locale/es';
 import es_ES from 'antd/lib/locale-provider/es_ES';
 // import eu_ES from 'antd/lib/locale/eu_ES'; There's no such translation on antd
@@ -40,6 +38,8 @@ import 'moment/locale/sv';
 import sv_SE from 'antd/lib/locale-provider/sv_SE';
 import 'moment/locale/zh-cn';
 import zh_CN from 'antd/lib/locale-provider/zh_CN';
+import 'moment/locale/en-gb';
+import en_GB from 'antd/lib/locale-provider/en_GB';
 
 // i18n
 export const getLocale = language => {


### PR DESCRIPTION
# What's the issue?
Ant Desing uses Moment js for Dates, so i18n in Moment JS, for some contents of the picker shown (Month, days of week, etc...) needs to be specified even if ConfigProvider from Antd knows the language used.
# How was resolved?
Create datePickerUtils.js to extract all the logic related to i18n of DatePicker and include translations from MomentJS to translate some contents of the picker