### PR TITLE
fix(gauge): start point for gauge on min value

### DIFF
--- a/src/components/Gauge.js
+++ b/src/components/Gauge.js
@@ -58,7 +58,7 @@ export const getValueSeries = (indicator, max, min, name, showAsPercentage) => {
       verticalAlign: 'bottom',
       format: '',
     },
-    threshold: 0,
+    threshold: min,
     tooltip: {
       pointFormat: `<span style="fill:${indicator.color}; stroke:${indicator.color}; border-color:${indicator.color};"><span style="color:${indicator.color};">\u25CF</span> <b>${indicator.tooltip}</b></span><br/>`,
     },

--- a/test/components/Gauge.test.js
+++ b/test/components/Gauge.test.js
@@ -46,7 +46,7 @@ describe('<Gauge>', () => {
         const resultingSerie = getValueSeries(
           givenProps.indicator,
           givenProps.max,
-          null,
+          givenProps.min,
           null,
           false
         );


### PR DESCRIPTION
# What's the issue?
Gauge starts always from "0". It should begin from min value of the Gauge

How was resolved?
Use min value on threshold when the serie of the main value is calculated