### PR TITLE
fix(fieldgroup): duplicated options for different Field Groups

### DIFF
--- a/src/components/FieldGroup.js
+++ b/src/components/FieldGroup.js
@@ -118,7 +118,7 @@ export const FieldGroup = props => {
       ? [
           ...values.map(value => ({
             ...value,
-            uuid: uniqueId(value.id),
+            uniqueId: uniqueId(value.id),
           })),
         ]
       : [];
@@ -137,12 +137,12 @@ export const FieldGroup = props => {
     'dataId',
   ]);
   const handleOnFieldClick = item => {
-    const { uuid, ...itemRest } = item;
+    const { uniqueId, ...itemRest } = item;
     onFieldClick(itemRest);
   };
 
   const handleOnChange = item => {
-    const { uuid, ...itemRest } = item;
+    const { uniqueId, ...itemRest } = item;
     onChange(itemRest);
   };
 
@@ -157,7 +157,7 @@ export const FieldGroup = props => {
       data-id={dataId}
     >
       {uniqueValues.map(item => {
-        const { uuid, value, label, icon, tooltip, isDisabled } = item;
+        const { uniqueId, value, label, icon, tooltip, isDisabled } = item;
         const isSelected = isFieldSelected(type, item, selectedField);
         const classesItem = classNames(
           'item',
@@ -170,8 +170,8 @@ export const FieldGroup = props => {
           <label
             className={classesItem}
             data-tooltip={tooltip}
-            htmlFor={`${uuid}_${value}`}
-            key={`${uuid}_${value}`}
+            htmlFor={`${uniqueId}_${value}`}
+            key={`${uniqueId}_${value}`}
             onClick={() => onFieldClick && handleOnFieldClick(item)}
             data-testid="field-group-label"
           >
@@ -186,7 +186,7 @@ export const FieldGroup = props => {
               />
             ) : null}
             <input
-              id={`${uuid}_${value}`}
+              id={`${uniqueId}_${value}`}
               onChange={() => onChange && handleOnChange(item)}
               type={type}
               name={name}
@@ -198,7 +198,7 @@ export const FieldGroup = props => {
           </label>
         );
         return tooltip ? (
-          <Tooltip title={tooltip} key={`tooltip_${uuid}`}>
+          <Tooltip title={tooltip} key={`tooltip_${uniqueId}`}>
             {getLabel()}
           </Tooltip>
         ) : (

--- a/src/components/FieldGroup.js
+++ b/src/components/FieldGroup.js
@@ -1,16 +1,17 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { uniqueId } from 'lodash';
 import find from 'lodash/find';
-import set from 'lodash/set';
-import { withTheme } from 'styled-components';
 import omit from 'lodash/omit';
-import Icon from './Icon';
-import { Tooltip } from './Tooltip';
-import { BUTTON_SIZE } from './Button';
+import set from 'lodash/set';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withTheme } from 'styled-components';
+import withDataId from '../components/DataId/withDataId';
 import { StyledFieldGroup } from '../styles/components/StyledFieldGroup';
 import theme from '../styles/theme';
-import withDataId from '../components/DataId/withDataId';
+import { BUTTON_SIZE } from './Button';
+import Icon from './Icon';
+import { Tooltip } from './Tooltip';
 
 const propTypes = {
   /**
@@ -112,7 +113,21 @@ export const FieldGroup = props => {
     theme,
     dataId,
   } = props;
-  const selectedField = getSelectedField(type, values, selectedValues, 'value');
+  const uniqueValues =
+    values.length > 0
+      ? [
+          ...values.map(value => ({
+            ...value,
+            uuid: uniqueId(value.id),
+          })),
+        ]
+      : [];
+  const selectedField = getSelectedField(
+    type,
+    uniqueValues,
+    selectedValues,
+    'value'
+  );
   const fieldGroupProps = omit(props, [
     'values',
     'selectedValues',
@@ -121,6 +136,16 @@ export const FieldGroup = props => {
     'onFieldClick',
     'dataId',
   ]);
+  const handleOnFieldClick = item => {
+    const { uuid, ...itemRest } = item;
+    onFieldClick(itemRest);
+  };
+
+  const handleOnChange = item => {
+    const { uuid, ...itemRest } = item;
+    onChange(itemRest);
+  };
+
   return (
     <StyledFieldGroup
       theme={theme}
@@ -131,8 +156,8 @@ export const FieldGroup = props => {
       {...fieldGroupProps}
       data-id={dataId}
     >
-      {values.map(item => {
-        const { id, value, label, icon, tooltip, isDisabled } = item;
+      {uniqueValues.map(item => {
+        const { uuid, value, label, icon, tooltip, isDisabled } = item;
         const isSelected = isFieldSelected(type, item, selectedField);
         const classesItem = classNames(
           'item',
@@ -145,9 +170,9 @@ export const FieldGroup = props => {
           <label
             className={classesItem}
             data-tooltip={tooltip}
-            htmlFor={id}
-            key={id}
-            onClick={() => onFieldClick && onFieldClick(item)}
+            htmlFor={`${uuid}_${value}`}
+            key={`${uuid}_${value}`}
+            onClick={() => onFieldClick && handleOnFieldClick(item)}
             data-testid="field-group-label"
           >
             {!icon && label ? label : null}
@@ -161,8 +186,8 @@ export const FieldGroup = props => {
               />
             ) : null}
             <input
-              id={id}
-              onChange={() => onChange && onChange(item)}
+              id={`${uuid}_${value}`}
+              onChange={() => onChange && handleOnChange(item)}
               type={type}
               name={name}
               value={value}
@@ -173,7 +198,7 @@ export const FieldGroup = props => {
           </label>
         );
         return tooltip ? (
-          <Tooltip title={tooltip} key={`tooltip_${id}`}>
+          <Tooltip title={tooltip} key={`tooltip_${uuid}`}>
             {getLabel()}
           </Tooltip>
         ) : (

--- a/src/components/SwitchPeriodComparative.js
+++ b/src/components/SwitchPeriodComparative.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { withTheme } from 'styled-components';
 import omit from 'lodash/omit';
-import { v4 as uuidv4 } from 'uuid';
-
+import { uniqueId } from 'lodash';
 import { ISO_FORMAT } from '../utils/dates';
 import { StyledSwitchPeriodComparative } from '../styles/components/StyledSwitchPeriodComparative';
 import FieldGroup from './FieldGroup';
@@ -139,8 +138,8 @@ export const SwitchPeriodComparative = props => {
   const previousPeriod = `${previousStartDate} - ${previousEndDate}`;
   const samePeriodLastYear = `${lastYearStartDate} - ${lastYearEndDate}`;
 
-  const prevId = uuidv4();
-  const lastId = uuidv4();
+  const prevId = uniqueId();
+  const lastId = uniqueId();
 
   return (
     <StyledSwitchPeriodComparative

--- a/test/components/FieldGroup.test.js
+++ b/test/components/FieldGroup.test.js
@@ -80,4 +80,31 @@ describe('<FieldGroup>', () => {
     fieldGroup.find('.item-hdd input').simulate('change');
     expect(mockCallBack).toBeCalled();
   });
+  it('Should run onChangeFunction for second FieldGroup when it changes', () => {
+    const mockCallBackFirst = jest.fn();
+    const mockCallBackSecond = jest.fn();
+    const fieldGroup = mount(
+      <>
+        <FieldGroup
+          values={mockCheckboxGroup}
+          selectedValues={mockSelectedCheckboxItem}
+          type="checkbox"
+          onChange={value => mockCallBackFirst(value)}
+        />
+        <FieldGroup
+          values={mockCheckboxGroup}
+          selectedValues={mockSelectedCheckboxItem}
+          type="checkbox"
+          onChange={value => mockCallBackSecond(value)}
+        />
+      </>
+    );
+    expect(fieldGroup.find('.item-hdd input').length).toBe(2);
+    fieldGroup
+      .find('.item-hdd input')
+      .at(1)
+      .simulate('change');
+    expect(mockCallBackFirst).not.toBeCalled();
+    expect(mockCallBackSecond).toBeCalled();
+  });
 });


### PR DESCRIPTION
# What's the issue?
Given two Fieldgroups were rendered with the same options for each of them
When an option of 2nd Field Group were selected
Then the value selected was applied on 1st Field Group
Instead to apply on 2nd Field Group

How was resolved?
It was included a generator of uniqueId from lodash in order to not repeat the ids between options