### PR TITLE
fix(gauge):correct indicator resizing behaviour

### DIFF
--- a/src/components/Gauge.js
+++ b/src/components/Gauge.js
@@ -268,7 +268,7 @@ const renderIndicatorLabel = (
   let textBox = currentChart.indicatorLabel.getBBox();
   if (
     textBox.width >
-    currentChart.axes[1].axisGroup.element.getBoundingClientRect().width * 0.7
+    currentChart.chartWidth / indicator.value.toString().length
   ) {
     currentChart.indicatorLabel.attr({
       text: applyScientific(parseFloat(indicator.value), decimalSeparator, 2),


### PR DESCRIPTION
fix(gauge):correct indicator resizing behaviour

getBoundingClientRect() was giving 0 for width on Safari, hence displaying Gauge widget always as cientific notation.
Changed approach to ensure a more consistent sizing of elements across browsers.
