### PR TITLE
fix(select): Show the option box when clicking in the chevron icon

### DIFF
--- a/src/lib/components/Select/Select.tsx
+++ b/src/lib/components/Select/Select.tsx
@@ -104,35 +104,6 @@ export const dropdownRenderSelect = (
     </StyledSelectDropdown>
 );
 
-export const renderUnselectedOption = (option: any, searchValue: string, dataId: string) => {
-    if (searchValue !== '' && (![...searchValue].every((char) => char === '*' || char === ' ') || !searchValue.includes(ALL_CHARACTER))) {
-        const regex = getRegExpBasedOnInput(searchValue);
-        if (regex === false) {
-            return (
-                <StyledSpanOption data-testid={`option-span-${option.value}`} data-id={`${dataId}.option-span-${option.value}`} value={option as string}>
-                    {option}
-                </StyledSpanOption>
-            );
-        }
-        const indices = findSubstringIndices(option as string, regex);
-        if (indices.start !== -1 && indices.end !== -1) {
-            return (
-                <StyledSpanOption data-testid={`option-span-${option}-bold`} data-id={`${dataId}.option-span-${option.value}-bold`} value={option as string}>
-                    {[...option].map((letter, index) => {
-                        const isBold = searchValue.includes(ALL_CHARACTER) ? index === indices.start || index === indices.end : index >= indices.start && index <= indices.end;
-                        return isBold ? <b key={letter}>{letter}</b> : letter;
-                    })}
-                </StyledSpanOption>
-            );
-        }
-    }
-    return (
-        <StyledSpanOption data-testid={`option-span-${option}`} value={option as string}>
-            {option}
-        </StyledSpanOption>
-    );
-};
-
 const isDisabledOption = (option: Option, selectedValues: Array<string | number>, pageSize?: number) => {
     if (pageSize !== undefined) return selectedValues.length >= pageSize && !selectedValues.includes(option.value);
     return option.disabled;
@@ -345,6 +316,7 @@ export const Select = withDataId(
                         optionRender={optionRender as (option: FlattenOptionData<BaseOptionType>, info: { index: number }) => React.ReactNode}
                         options={options}
                         loading={isLoading}
+                        open={showDropdown}
                         placeholder={placeholder}
                         ref={(r) => {
                             ref.current = r;

--- a/tests/Select.test.tsx
+++ b/tests/Select.test.tsx
@@ -1,5 +1,5 @@
 import { ButtonPaginationSelector, getButtonText } from '@components/Select/ButtonPaginationSelector';
-import { tagRenderButtonPagination, dropdownRenderSelect, renderUnselectedOption, Select } from '@components/Select/Select';
+import { tagRenderButtonPagination, dropdownRenderSelect, Select } from '@components/Select/Select';
 import { filterOption, getOptionsBySearch } from '@components/Select/selectUtils';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vitest } from 'vitest';
@@ -321,20 +321,7 @@ describe('Ancillary functions', () => {
             expect(buttonSelectAll).toBeNull();
         });
     });
-    describe('renderUnselectedOption', () => {
-        it('should render an simple option when no search value', () => {
-            const option = 'Test 1';
-            render(renderUnselectedOption(option, '', 'dataId'));
-            const optionWrapper = screen.getByTestId('option-span-Test 1');
-            expect(optionWrapper).toBeTruthy();
-        });
-        it('should render an bold option when search value matches', () => {
-            const option = 'Test 1';
-            render(renderUnselectedOption(option, 'Test', 'dataId'));
-            const optionWrapper = screen.getByTestId('option-span-Test 1-bold');
-            expect(optionWrapper).toBeTruthy();
-        });
-    });
+    
 });
 
 describe('Select', () => {


### PR DESCRIPTION
The prop open was missing in the case of single select and there was a method that wasn't used except in the test, so I removed it