### PR TITLE
fix(pagination): use anchor elements for page items to fix accessibility

### DIFF
--- a/src/lib/components/Pagination/Pagination.tsx
+++ b/src/lib/components/Pagination/Pagination.tsx
@@ -7,12 +7,12 @@ import defaultTheme from '@utils/theme';
 
 export const itemRender = (current: number) => (page: number, type: 'page' | 'prev' | 'next' | 'jump-prev' | 'jump-next', element: React.ReactNode) => {
     if (type === 'prev') {
-        return <Icon name='chevron_left_l' color='gray900' size={12} ariaLabel='' />;
+        return <a role='link'><Icon name='chevron_left_l' color='gray900' size={12} ariaLabel='' /></a>;
     }
     if (type === 'next') {
-        return <Icon name='chevron_right_l' color='gray900' size={12} ariaLabel='' />;
+        return <a role='link'><Icon name='chevron_right_l' color='gray900' size={12} ariaLabel='' /></a>;
     }
-    if (type === 'page') return <span aria-current={current === page ? 'page' : undefined}>{page}</span>;
+    if (type === 'page') return <a role='link' aria-current={current === page ? 'page' : undefined}>{page}</a>;
     return element;
 };
 
@@ -46,12 +46,12 @@ export const Pagination = (props: PaginationProps) => {
 
     const changePage = (page: number) => {
         setTimeout(() => {
-            const liOldCurrentPage = document.querySelector<HTMLSpanElement>(`span[aria-current='page']`);
+            const liOldCurrentPage = document.querySelector<HTMLAnchorElement>(`a[aria-current='page']`);
             if (liOldCurrentPage)
                 liOldCurrentPage.removeAttribute('aria-current');
             const liNewCurrentPage = document.querySelector<HTMLLIElement>(`li[title='${page}']`);
             if (liNewCurrentPage)
-                liNewCurrentPage.querySelector('span')!.setAttribute('aria-current', 'page');
+                liNewCurrentPage.querySelector('a')!.setAttribute('aria-current', 'page');
         }, 0);
     };
 

--- a/tests/Pagination.test.tsx
+++ b/tests/Pagination.test.tsx
@@ -1,7 +1,7 @@
 import { expect, describe, it } from 'vitest';
 import { render } from '@testing-library/react';
 
-import { Pagination } from '@components';
+import { Pagination, itemRender } from '@components';
 
 describe('<Pagination>', () => {
     it('Should render the correct classNamePrefix component', () => {
@@ -13,5 +13,63 @@ describe('<Pagination>', () => {
         const pagination = render(<Pagination total={100} pageSize={10} defaultCurrent={6} />);
         const icon = pagination.getAllByTestId('icon');
         expect(icon.length).toEqual(2);
+    });
+
+    it('Should render page items as anchor elements', () => {
+        const pagination = render(<Pagination total={20} pageSize={10} defaultCurrent={1} />);
+        const links = pagination.container.querySelectorAll('.ant-pagination-item a[role="link"]');
+        expect(links.length).toBeGreaterThan(0);
+    });
+
+    it('Should set aria-current="page" on the active page anchor', () => {
+        const pagination = render(<Pagination total={20} pageSize={10} defaultCurrent={1} />);
+        const activeLink = pagination.container.querySelector('.ant-pagination-item-active a[role="link"]');
+        expect(activeLink).not.toBeNull();
+        expect(activeLink?.getAttribute('aria-current')).toBe('page');
+    });
+
+    it('Should not set aria-current on inactive page anchors', () => {
+        const pagination = render(<Pagination total={20} pageSize={10} defaultCurrent={1} />);
+        const inactiveLinks = pagination.container.querySelectorAll<Element>('.ant-pagination-item:not(.ant-pagination-item-active) a[role="link"]');
+        inactiveLinks.forEach((link) => {
+            expect(link.getAttribute('aria-current')).toBeNull();
+        });
+    });
+
+    it('Should wrap prev and next icons in anchor elements', () => {
+        const pagination = render(<Pagination total={20} pageSize={10} defaultCurrent={1} />);
+        const prevAnchor = pagination.container.querySelector('.ant-pagination-prev a[role="link"]');
+        const nextAnchor = pagination.container.querySelector('.ant-pagination-next a[role="link"]');
+        expect(prevAnchor).not.toBeNull();
+        expect(nextAnchor).not.toBeNull();
+    });
+
+    describe('itemRender', () => {
+        it('Should render an anchor with aria-current="page" for the active page', () => {
+            const renderFn = itemRender(2);
+            const { container } = render(<>{renderFn(2, 'page', null)}</>);
+            const anchor = container.querySelector('a');
+            expect(anchor?.getAttribute('aria-current')).toBe('page');
+            expect(anchor?.textContent).toBe('2');
+        });
+
+        it('Should render an anchor without aria-current for inactive pages', () => {
+            const renderFn = itemRender(1);
+            const { container } = render(<>{renderFn(3, 'page', null)}</>);
+            const anchor = container.querySelector('a');
+            expect(anchor?.getAttribute('aria-current')).toBeNull();
+        });
+
+        it('Should render an anchor wrapping the prev icon', () => {
+            const renderFn = itemRender(1);
+            const { container } = render(<>{renderFn(0, 'prev', null)}</>);
+            expect(container.querySelector('a')).not.toBeNull();
+        });
+
+        it('Should render an anchor wrapping the next icon', () => {
+            const renderFn = itemRender(1);
+            const { container } = render(<>{renderFn(0, 'next', null)}</>);
+            expect(container.querySelector('a')).not.toBeNull();
+        });
     });
 });


### PR DESCRIPTION
What changed

Replaced <span> with <a role="link"> for page number items in itemRender
Wrapped prev/next icon controls in <a role="link"> elements
Updated aria-current="page" attribute management in changePage to target <a> instead of <span>
Why
Pagination page items and prev/next controls were rendered as <span> elements, which are not announced as interactive navigation links by screen readers. This caused an accessibility failure — assistive technologies had no semantic cue that these elements were navigable links. Replacing them with <a role="link"> ensures correct announcement and keyboard discoverability.

Jira ticket
DASH-2635-fix-link-html-tags

Testing done

Added 8 new unit tests covering:
Page items render as <a role="link"> elements
Active page has aria-current="page" on the anchor
Inactive pages have no aria-current
Prev/next controls are wrapped in anchor elements
itemRender unit tests for page, prev, and next types
All 10 Pagination tests pass: npx vitest run tests/Pagination.test.tsx